### PR TITLE
New Menu - View remote

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -9,6 +9,7 @@ import {
 } from "./src/settings";
 import { InitNewRepoHandler } from "src/initNewRepoHandler";
 import { GitDiffHandler } from "src/gitDiffHandler";
+import { ViewRemoteHandler } from "src/viewRemoteHandler";
 import { ContextMenuInstaller } from "src/contextMenuInstaller";
 import { CommandRegister } from "src/commandRegister";
 import { CapabilityProvider } from "src/capabilityProvider";
@@ -43,7 +44,8 @@ export default class GitFileExplorerPlugin extends Plugin {
 			new GitDiffHandler(this.getVaultBasePath())
 				.withCallback(() => this.widgetManager?.update()),
 			new InitNewRepoHandler(this.getVaultBasePath())
-				.withCallback(() => this.widgetManager?.update())
+				.withCallback(() => this.widgetManager?.update()),
+			new ViewRemoteHandler(this.getVaultBasePath())
 		];
 
 		const contextMenuInstaller = new ContextMenuInstaller(this);

--- a/src/viewRemoteHandler.ts
+++ b/src/viewRemoteHandler.ts
@@ -1,0 +1,120 @@
+import { TFile, TFolder } from "obsidian";
+import { GitRepository } from "./git/gitRepository";
+import { join } from "path";
+import { CapabilityProvider } from "./capabilityProvider";
+
+export class ViewRemoteHandler implements CapabilityProvider {
+	private static VIEW_REMOTE = "View remote";
+	private static COMMAND_ID = "view-remote-repo";
+
+	constructor(private basePath: string) {}
+
+	public async execute(fileOrFolder: TFile | TFolder): Promise<void> {
+		// First check if this is applicable (within a git repository)
+		const folderPath = fileOrFolder instanceof TFolder ? fileOrFolder.path : fileOrFolder.parent?.path;
+		if (!folderPath) return;
+
+		const absPath = this.buildAbsPathTo(folderPath);
+		
+		// Check if this file/folder is within a git repository
+		const repoRoot = this.findGitRepoRoot(absPath);
+		if (!repoRoot) return;
+		
+		try {
+			const gitRepo = await GitRepository.getInstance(repoRoot);
+			
+			// Check if repository has a remote
+			if (!(await gitRepo.hasRemote())) {
+				console.log("No remote repository configured");
+				return;
+			}
+
+			// Get the remote URL
+			const remoteUrl = await this.getRemoteUrl(repoRoot);
+			if (!remoteUrl) {
+				console.log("Could not determine remote URL");
+				return;
+			}
+
+			// Convert git URL to web URL if needed
+			const webUrl = this.convertToWebUrl(remoteUrl);
+			
+			console.log(`Opening remote repository: ${webUrl}`);
+			
+			// Open the URL in the default browser
+			window.open(webUrl, '_blank');
+			
+		} catch (error) {
+			console.error("Failed to open remote repository:", error);
+		}
+	}
+
+	public getCommandName(): string {
+		return ViewRemoteHandler.VIEW_REMOTE;
+	}
+
+	public getIcon(): string {
+		return "external-link";
+	}
+	
+	public getCommandId(): string {
+		return ViewRemoteHandler.COMMAND_ID;
+	}
+
+	private buildAbsPathTo = (path: string) => join(this.basePath, path);
+	
+	// Find the git repository root by walking up the directory tree
+	private findGitRepoRoot(startPath: string): string | null {
+		let currentPath = startPath;
+		
+		while (currentPath && currentPath.length > 0) {
+			if (GitRepository.isGitRepo(currentPath)) {
+				return currentPath;
+			}
+			
+			// Go up one directory
+			const parentPath = join(currentPath, "..");
+			
+			// If we're at the root, stop searching
+			if (parentPath === currentPath) {
+				return null;
+			}
+			
+			currentPath = parentPath;
+		}
+		
+		return null;
+	}
+
+	private async getRemoteUrl(repoPath: string): Promise<string | null> {
+		try {
+			const { exec } = require('child_process');
+			const { promisify } = require('util');
+			const execAsync = promisify(exec);
+			
+			const { stdout } = await execAsync('git remote get-url origin', { cwd: repoPath });
+			return stdout.trim();
+		} catch (error) {
+			console.error("Error getting remote URL:", error);
+			return null;
+		}
+	}
+
+	private convertToWebUrl(gitUrl: string): string {
+		// Handle SSH URLs (git@github.com:user/repo.git)
+		if (gitUrl.startsWith('git@')) {
+			const sshMatch = gitUrl.match(/git@([^:]+):(.+)\.git$/);
+			if (sshMatch) {
+				return `https://${sshMatch[1]}/${sshMatch[2]}`;
+			}
+		}
+		
+		// Handle HTTPS URLs (https://github.com/user/repo.git)
+		if (gitUrl.startsWith('https://')) {
+			return gitUrl.replace(/\.git$/, '');
+		}
+		
+		// Return as-is if we can't parse it
+		return gitUrl;
+	}
+}


### PR DESCRIPTION
## What
This adds an extra menu called "View remote" that will open up the remote repo in your browser when you click on it 

## Why
- It's nice to be able to use the extra analysis tools of Github or Gitlab or Gitea for a repo
- It's annoying to remember where this repo is hosted if you have many repos
- Github desktop has this feature on right click as well so I am used to having it ... 

## How
- Just Control + Click on folder to expose menu

### On Obsidian
<img width="160" height="125" alt="Screenshot 2025-08-27 at 11 46 21 AM" src="https://github.com/user-attachments/assets/42671b06-b3c8-4963-9e5a-153ecd20b048" />
n with this pull request

### Example of Github Desktop
<img width="200"  alt="Screenshot 2025-08-27 at 11 47 49 AM" src="https://github.com/user-attachments/assets/a6dacc1c-75f8-44fd-8995-20828d62d391" />

