### PR TITLE
fix: support git repository at vault root

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -36,6 +36,7 @@ export default class GitFileExplorerPlugin extends Plugin {
 			this.getVaultBasePath()
 		);
 
+		await this.widgetManager.initializeRoot();
 		await this.widgetManager.update();
 
 		this.registerEventListeners(this.widgetManager.update);
@@ -44,7 +45,10 @@ export default class GitFileExplorerPlugin extends Plugin {
 			new GitDiffHandler(this.getVaultBasePath())
 				.withCallback(() => this.widgetManager?.update()),
 			new InitNewRepoHandler(this.getVaultBasePath())
-				.withCallback(() => this.widgetManager?.update()),
+				.withCallback(() => {
+					this.widgetManager?.initializeRoot();
+					this.widgetManager?.update();
+				}),
 			new ViewRemoteHandler(this.getVaultBasePath())
 		];
 

--- a/src/widgets/navColorUpdater.ts
+++ b/src/widgets/navColorUpdater.ts
@@ -25,7 +25,10 @@ export class NavColorUpdater {
 
         const changedPaths = gitNodes.map((node) => {
             const rel = node.path.replace(/\\/g, "/");
-            return path.posix.normalize(`${this.repoRelPath}/${rel}`);
+            const normalized = path.posix.normalize(`${this.repoRelPath}/${rel}`);
+            // Root repos produce "/src/file.ts" — strip leading slash to match Obsidian data-path
+            const dataPath = normalized.startsWith("/") ? normalized.slice(1) : normalized;
+            return dataPath;
         });
         
         const cssRules: string[] = [];

--- a/src/widgets/widgetManager.ts
+++ b/src/widgets/widgetManager.ts
@@ -3,6 +3,7 @@ import { GitWidgetFactory } from "./gitWidgetFactory";
 import { Widget } from "./widget";
 import { AFItem, FolderItem } from "obsidian";
 import { join } from "path";
+import { existsSync } from "fs";
 import { SmartDebouncer } from "./utils/smartDebouncer";
 import { GitEventBus } from "./utils/eventBus";
 
@@ -21,6 +22,7 @@ export class WidgetManager {
 
 	public async update(): Promise<void> {
 		this.smartDebouncer.debounce("*", async () => {
+			await this.addWidgetsForRoot();
 			await this.addWidgetsForNewFolderItems();
 			await this.updateExistingWidgets();
 		});
@@ -39,10 +41,24 @@ export class WidgetManager {
 		await Promise.all(this.widgets.map((widget) => widget.update()));
 	};
 
+	private addWidgetsForRoot = async () => {
+		if (!existsSync(join(this.basePath, ".git"))) return;
+
+		const rootEl = this.createRootWidgetContainer();
+		if (!rootEl) return;
+
+		const alreadyWidgetized = this.widgets.some((widget) =>
+			widget.getParent().isEqualNode(rootEl)
+		);
+		if (alreadyWidgetized) return;
+
+		await this.registerWidgets(rootEl, this.basePath);
+	};
+
 	private addWidgetsForNewFolderItems = async () =>
 		await this.fileExplorerHandler.doWithFolderItem(async (folderItem) => {
 			if (this.isNewFolderItem(folderItem))
-				await this.createWidgetsForFolderItem(folderItem);
+				await this.registerWidgets(folderItem.selfEl, this.getFullPathToItem(folderItem));
 			});
 
 	private isNewFolderItem = (folderItem: FolderItem) =>
@@ -50,22 +66,15 @@ export class WidgetManager {
 			widget.getParent().isEqualNode(folderItem.selfEl)
 		);
 
-	private async createWidgetsForFolderItem(
-		folderItem: FolderItem
-	): Promise<void> {
+	private async registerWidgets(parent: HTMLElement, absPath: string): Promise<void> {
 		try {
-			const parent = folderItem.selfEl;
-			const absPathToFolder = this.getFullPathToItem(folderItem);
-			const widgets = await this.factory.buildWidgets(
-				parent,
-				absPathToFolder
-			);
-			
+			const widgets = await this.factory.buildWidgets(parent, absPath);
+
 			if (widgets.length > 0) {
 				this.widgets.push(...widgets);
-				
+
 				widgets.forEach(widget => {
-					this.eventBus.subscribe(absPathToFolder, (updatedRepoPath) => {
+					this.eventBus.subscribe(absPath, (updatedRepoPath) => {
 						this.smartDebouncer.debounce(updatedRepoPath+"-"+widget.getName(), async () => {
 							await widget.update();
 						});
@@ -75,6 +84,24 @@ export class WidgetManager {
 		} catch (err) {
 			return;
 		}
+	}
+
+	private createRootWidgetContainer(): HTMLElement | undefined {
+		const containerEl = this.fileExplorerHandler.fileExplorer?.containerEl;
+		if (!containerEl) return undefined;
+
+		const existing = containerEl.querySelector<HTMLElement>('#git-root-widget-container');
+		if (existing) return existing;
+
+		const navHeader = containerEl.querySelector<HTMLElement>('.nav-header');
+		if (!navHeader) return undefined;
+
+		const rootEl = document.createElement('div');
+		rootEl.id = 'git-root-widget-container';
+		rootEl.setAttribute('data-path', '/');
+		navHeader.appendChild(rootEl);
+
+		return rootEl;
 	}
 
 	private getFullPathToItem(item: AFItem): string {

--- a/src/widgets/widgetManager.ts
+++ b/src/widgets/widgetManager.ts
@@ -20,9 +20,22 @@ export class WidgetManager {
 		this.update = this.update.bind(this);
 	}
 
+	public initializeRoot = async () => {
+		if (!existsSync(join(this.basePath, ".git"))) return;
+
+		const rootEl = this.createRootWidgetContainer();
+		if (!rootEl) return;
+
+		const alreadyWidgetized = this.widgets.some((widget) =>
+			widget.getParent().isEqualNode(rootEl)
+		);
+		if (alreadyWidgetized) return;
+
+		await this.registerWidgets(rootEl, this.basePath);
+	};
+
 	public async update(): Promise<void> {
 		this.smartDebouncer.debounce("*", async () => {
-			await this.addWidgetsForRoot();
 			await this.addWidgetsForNewFolderItems();
 			await this.updateExistingWidgets();
 		});
@@ -39,20 +52,6 @@ export class WidgetManager {
 
 	private updateExistingWidgets = async () => {
 		await Promise.all(this.widgets.map((widget) => widget.update()));
-	};
-
-	private addWidgetsForRoot = async () => {
-		if (!existsSync(join(this.basePath, ".git"))) return;
-
-		const rootEl = this.createRootWidgetContainer();
-		if (!rootEl) return;
-
-		const alreadyWidgetized = this.widgets.some((widget) =>
-			widget.getParent().isEqualNode(rootEl)
-		);
-		if (alreadyWidgetized) return;
-
-		await this.registerWidgets(rootEl, this.basePath);
 	};
 
 	private addWidgetsForNewFolderItems = async () =>

--- a/src/widgets/widgetManager.ts
+++ b/src/widgets/widgetManager.ts
@@ -87,19 +87,18 @@ export class WidgetManager {
 	}
 
 	private createRootWidgetContainer(): HTMLElement | undefined {
-		const containerEl = this.fileExplorerHandler.fileExplorer?.containerEl;
-		if (!containerEl) return undefined;
-
-		const existing = containerEl.querySelector<HTMLElement>('#git-root-widget-container');
+		const existing = document.querySelector<HTMLElement>('#git-root-widget-container');
 		if (existing) return existing;
 
-		const navHeader = containerEl.querySelector<HTMLElement>('.nav-header');
-		if (!navHeader) return undefined;
+		const vaultProfile = document.querySelector<HTMLElement>('.workspace-sidedock-vault-profile');
+		if (!vaultProfile) return undefined;
 
 		const rootEl = document.createElement('div');
 		rootEl.id = 'git-root-widget-container';
 		rootEl.setAttribute('data-path', '/');
-		navHeader.appendChild(rootEl);
+
+		const vaultActions = vaultProfile.querySelector('.workspace-drawer-vault-actions');
+		vaultProfile.insertBefore(rootEl, vaultActions);
 
 		return rootEl;
 	}

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,28 @@
+.nav-header:has(#git-root-widget-container) {
+    position: relative;
+}
+#git-root-widget-container {
+    position: absolute;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+}
+#git-root-widget-container .git-widget {
+    position: static;
+    font-size: 0.65em;
+    height: auto;
+    width: auto;
+    padding: 1px 4px;
+    margin-left: 0;
+    border-radius: 3px;
+    line-height: 1.4;
+}
+#git-root-widget-container .git-widget:nth-of-type(1) {
+    right: auto;
+}
 .git-widget {
     position: absolute;
     right: 0;

--- a/styles.css
+++ b/styles.css
@@ -1,27 +1,8 @@
-.nav-header:has(#git-root-widget-container) {
-    position: relative;
-}
 #git-root-widget-container {
-    position: absolute;
-    right: 4px;
-    top: 50%;
-    transform: translateY(-50%);
-    display: inline-flex;
-    align-items: center;
-    gap: 2px;
-}
-#git-root-widget-container .git-widget {
-    position: static;
-    font-size: 0.65em;
-    height: auto;
-    width: auto;
-    padding: 1px 4px;
-    margin-left: 0;
-    border-radius: 3px;
-    line-height: 1.4;
-}
-#git-root-widget-container .git-widget:nth-of-type(1) {
-    right: auto;
+    position: relative;
+    flex: 0 0 auto;
+    min-width: 8.5em;
+    height: 1.5em;
 }
 .git-widget {
     position: absolute;


### PR DESCRIPTION
## Summary

Fixes #20 — the plugin now detects and displays widgets for a git repository at the vault root, not just in subfolders.

### Root cause

`FileExplorerHandler.doWithFolderItem()` iterates `fileExplorer.fileItems`, which excludes the vault root. Obsidian's file explorer has no DOM element or `FolderItem` entry for the vault root — its children are rendered directly.

### Changes

- **`widgetManager.ts`** — added `addWidgetsForRoot()` that checks for `.git` at the vault root, injects a lightweight widget container into the file explorer's `nav-header`, and registers widgets via a new shared `registerWidgets()` method (extracted from the existing `**createWidgetsForFolderItem**` to eliminate duplication). **This was the biggest cut into existing logic, please review with care.**
- **`navColorUpdater.ts`** — fixed path normalization to strip leading `/` so CSS selectors match Obsidian's `data-path` format for root repos
- **`styles.css`** — added compact styling for the root widget container positioned in the nav-header

### Notes

- Subfolder repo behavior is completely untouched
- `FileExplorerHandler` has no changes — all new logic lives in `WidgetManager`
- The root widget container is only created when `.git` exists at the vault root
- Tested in Obsidian with a monorepo vault (root-level git repo, no subfolder repos)
- Unwanted overlay in root git repos. But other solutions I've tried introduced even more compromises.
<img width="310" height="166" alt="image" src="https://github.com/user-attachments/assets/a50538d8-5460-46b8-82c7-8e1105a1e6da" />

